### PR TITLE
Add unit tests and travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+cache: pip
+python: "2.7"
+install:
+  - pip install -r requirements.txt
+  - pip install -r testrequirements.txt
+  - pip install coveralls
+
+script:
+  coverage run --source='.' -m unittest discover --pattern='*_test.py'
+after_success:
+  coveralls
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: python
+sudo: required
+
 cache: pip
 python: "2.7"
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y paris-traceroute
+
 install:
   - pip install -r requirements.txt
-  - pip install -r testrequirements.txt
-  - pip install coveralls
+  - pip install -r test-requirements.txt
+  - sudo pip install coverage  # Because we have to call if from sudo
 
 script:
-  coverage run --source='.' -m unittest discover --pattern='*_test.py'
+  - sudo python -m coverage run --source='.' --omit '*_test.py' -m unittest discover --pattern='*_test.py'
+
 after_success:
   coveralls
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-SideStream
+SideStream  [![Test Status](https://travis-ci.org/gfr10598/sidestream.svg?branch=master)](https://travis-ci.org/gfr10598/sidestream.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/gfr10598/sidestream/badge.svg?branch=master)](https://coveralls.io/github/gfr10598/sidestream?branch=master)
 ==========
 
 Description of how SideStream works and the data that collects.

--- a/exitstats.py
+++ b/exitstats.py
@@ -148,19 +148,19 @@ def main(argv=None):
 
   if argv is None:
     argv = sys.argv
-  if len(sys.argv) == 1:
-      server=""
-  elif len(sys.argv) == 2:
-    server=sys.argv[1]+"/"
+  if len(argv) == 1:
+      server = ""
+  elif len(argv) == 2:
+    server = argv[1]+"/"
   else:
     print "Usage: %s [server_name]"%sys.argv[0]
     sys.exit()
 
   a = Web100Agent()
-  closed=[]
+  closed = []
   while True:
     cl = a.all_connections()
-    newclosed=[]
+    newclosed = []
     for c in cl:
       try:
         if c.read('State') == 1:

--- a/exitstats.py
+++ b/exitstats.py
@@ -143,13 +143,11 @@ def showconn(c):
 
 # Main
 
-def main(argv=None):
+def main(argv):
   print "Starting exitstats"
 
-  if argv is None:
-    argv = sys.argv
   if len(argv) == 1:
-      server = ""
+    server = ""
   elif len(argv) == 2:
     server = argv[1]+"/"
   else:
@@ -174,4 +172,4 @@ def main(argv=None):
     time.sleep(5)
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv))

--- a/exitstats.py
+++ b/exitstats.py
@@ -7,10 +7,14 @@ stats.
 
 print "Starting exitstats"
 
-from Web100 import *
 import time
 import sys
 import os
+
+try:
+  from Web100 import *
+except ImportError:
+  print "Error importing web100"
 
 stdvars=[
 "LocalAddress", "LocalPort", "RemAddress", "RemPort", "State", "SACKEnabled",
@@ -40,7 +44,7 @@ stdvars=[
 "WAD_CwndAdjust"
 ]
 
-vars=None
+active_vars=None
 def setkey(snap):
   """
   Select the variables to be saved.   By default this is the same as
@@ -51,23 +55,23 @@ def setkey(snap):
   Thus the keys will usually be same from data set to data set, but this
   is not guaranteed.
   """
-  global vars, stdvars
-  vars=[]
+  global active_vars, stdvars
+  active_vars=[]
   s=snap.copy()
   for k in stdvars:
     if k in s:
-      vars.append(k)
+      active_vars.append(k)
       del s[k]
 #   else:
 #     print "Standard variable %s omited"%k
   for k in s:
 #   print "Non-std variable found:", k
-    vars.append(k)
+    active_vars.append(k)
 
-def showkey(f, snap):
-  global vars
+def showkey(f):
+  global active_vars
   f.write("K: cid PollTime")
-  for k in vars:
+  for k in active_vars:
     f.write(" "+k)
   f.write("\n")
 
@@ -100,7 +104,7 @@ logtime=(60*60)
 logf=None
 olt = -1
 olddir=""
-def getlogf(t, snap):
+def getlogf(t):
   global olt, logtime, logf, server
   lt = int(t / logtime)*logtime
   if lt != olt:
@@ -113,13 +117,13 @@ def getlogf(t, snap):
     logname=time.strftime("%Y/%m/%d/%%s%Y%m%dT%TZ_ALL%%d.web100", time.gmtime(lt))%(server, 0)
     print "Opening:", logname
     logf=open(logname, "a")
-    showkey(logf, snap)
+    showkey(logf)
   return logf
 
 def showconn(c):
-  global vars
+  global active_vars
   snap = c.readall()
-  if not vars:
+  if not active_vars:
     setkey(snap)
   # Ignore connections to loopback and Planet Lab Control (PLC)
   if snap["RemAddress"] == "127.0.0.1":
@@ -131,7 +135,7 @@ def showconn(c):
   t = time.time()
   logf=getlogf(t, snap)
   logf.write("C: %d %s"%(c.cid, time.strftime("%Y-%m-%d-%H:%M:%SZ", time.gmtime(t))))
-  for v in vars:
+  for v in active_vars:
     logf.write(" "+str(snap[v]))
   logf.write("\n")
   logf.flush()
@@ -139,29 +143,35 @@ def showconn(c):
 
 # Main
 
-if len(sys.argv) == 1:
-  server=""
-elif len(sys.argv) == 2:
-  server=sys.argv[1]+"/"
-else:
-  print "Usage: %s [server_name]"%sys.argv[0]
-  sys.exit()
+def main(argv=None):
+  print "Starting exitstats"
 
-a = Web100Agent()
-closed=[]
-while True:
-  cl = a.all_connections()
-  newclosed=[]
-  for c in cl:
-    try:
-      if c.read('State') == 1:
-        newclosed.append(c.cid)
-        if not c.cid in closed:
-          showconn(c)
-    except Exception, e:
-#     print "Exception:", e
-      pass
-  closed=newclosed;
-  time.sleep(5)
+  if argv is None:
+    argv = sys.argv
+  if len(sys.argv) == 1:
+      server=""
+  elif len(sys.argv) == 2:
+    server=sys.argv[1]+"/"
+  else:
+    print "Usage: %s [server_name]"%sys.argv[0]
+    sys.exit()
 
+  a = Web100Agent()
+  closed=[]
+  while True:
+    cl = a.all_connections()
+    newclosed=[]
+    for c in cl:
+      try:
+        if c.read('State') == 1:
+          newclosed.append(c.cid)
+          if not c.cid in closed:
+            showconn(c)
+      except Exception, e:
+#       print "Exception:", e
+        pass
+    closed=newclosed;
+    time.sleep(5)
 
+if __name__ == "__main__":
+    sys.exit(main())

--- a/exitstats_test.py
+++ b/exitstats_test.py
@@ -1,0 +1,28 @@
+"""Tests for sidestream."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import os
+import unittest
+import time
+
+import exitstats
+
+class ExitstatsTest(unittest.TestCase):
+
+  def testSetKey(self):
+    exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
+    self.assertEqual(sorted(exitstats.active_vars), ['bar', 'baz', 'foo'])
+    # stdvars go in front...
+    exitstats.setkey({'MinA':3, 'MinB':2, 'MinRTT':1})
+    self.assertEqual(exitstats.active_vars[0], 'MinRTT')
+    self.assertTrue('MinA' in  exitstats.active_vars)
+
+    exitstats.server = server = 'foo'
+    _ = exitstats.getlogf(3600*945214)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/exitstats_test.py
+++ b/exitstats_test.py
@@ -13,16 +13,43 @@ import exitstats
 
 class ExitstatsTest(unittest.TestCase):
 
-  def testSetKey(self):
+  def testSetkey(self):
     exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
     self.assertEqual(sorted(exitstats.active_vars), ['bar', 'baz', 'foo'])
-    # stdvars go in front...
+    # stdvars should appear before others...
     exitstats.setkey({'MinA':3, 'MinB':2, 'MinRTT':1})
     self.assertEqual(exitstats.active_vars[0], 'MinRTT')
     self.assertTrue('MinA' in  exitstats.active_vars)
 
-    exitstats.server = server = 'foo'
-    _ = exitstats.getlogf(3600*945214)
+  def testGetlogf(self):
+    '''Check that getlogf successfully create the expected file'''
+    # Need to set up the variables key to avoid error.
+    exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
+
+    logdir = '2062/11/20/'
+    logname = 'server20621120T10:00:00Z_ALL0.web100'
+    gm = time.gmtime(3600*814234)
+    try:
+      os.remove(logdir + logname)
+      os.removedirs(logdir)
+    except OSError:
+      pass
+
+    exitstats.server = server = 'server'
+    _ = exitstats.getlogf(3600*814234)
+
+    try:
+      os.stat(logdir + logname)
+    except OSError as e:
+      print('Expected file not created: ' + logdir + logname)
+      print(e)
+
+    # Clean up
+    try:
+      os.remove(logdir + logname)
+      os.removedirs(logdir)
+    except OSError:
+      pass
 
 if __name__ == '__main__':
   unittest.main()

--- a/paris_rollins.py
+++ b/paris_rollins.py
@@ -28,10 +28,18 @@ import sys
 import time
 
 import platform
-import Web100
+try:
+    import Web100
+except ImportError:
+    print "Error importing web100"
 
 # What binary to use for paris-traceroute
 PARIS_TRACEROUTE_BIN = '/usr/local/bin/paris-traceroute'
+try:
+  os.stat(PARIS_TRACEROUTE_BIN)
+except OSError as e:
+  PARIS_TRACEROUTE_BIN = '/usr/sbin/paris-traceroute'
+
 # What binary to use for timeout (see comment about python/dependencies, above)
 TIMEOUT_BIN = '/usr/bin/timeout'
 # paris-traceroute is run at this nice level, to minimize impact on the host.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+mock
+coveralls
+coverage
+


### PR DESCRIPTION
This PR:
  Does a small refactoring to add main() to exitstats to allow unit testing.
  Add exitstats_test.py with some very basic unit tests
  Adds .travis.yml to configure travis testing
  Tweaks paris_traceroute.py so that testing can run without web100.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/22)
<!-- Reviewable:end -->
