### PR TITLE
Introduce option to log to separate file for each server IP address.

### DIFF
--- a/exitstats.py
+++ b/exitstats.py
@@ -107,7 +107,18 @@ def closeLogs():
     if v.f: v.f.close()
   logs.clear()
 
-def getLogFile(t, local_ip='all'):
+def logName(server, gm, local_ip):
+  ''' Form log directory name, and log name
+  '''
+  logdir= time.strftime("%Y/%m/%d/", gm)
+  ts = time.strftime("%Y%m%dT%TZ", gm)
+  if local_ip == None:
+    return logdir, "%s%s_ALL%d.web100"%(server, ts ,0)
+  else:
+    return logdir, "%s%s_ALL%d-%s.web100"%(server, ts ,0, local_ip)
+
+
+def getLogFile(t, local_ip=None):
   global one_hour, logs, log_time, server
   hour_time = int(t / one_hour) * one_hour
 
@@ -120,15 +131,17 @@ def getLogFile(t, local_ip='all'):
     return logs[local_ip].f
   else:
     gm = time.gmtime(hour_time)
-    logdir= time.strftime("%Y/%m/%d/", gm)
     mkdirs(logdir)
     ts = time.strftime("%Y%m%dT%TZ", gm)
     logname=logdir+"%s%s_ALL%d-%s-web100"%(server, ts ,0, local_ip)
     print "Opening:", logname
-    logf = open(logname, "a")
+    logdir, logname = logName(server, gm, local_ip)
+    mkdirs(logdir)
+    print "Opening:", logdir+logname
+    logf = open(logdir+logname, "a")
     logHeader(logf)
     # Add the entry to the logs dict.
-    logs[local_ip] = LogInfo(logname, f=logf)
+    logs[local_ip] = LogInfo(logdir+logname, f=logf)
     return logf
 
 def logConnection(c):

--- a/exitstats_test.py
+++ b/exitstats_test.py
@@ -21,7 +21,19 @@ class ExitstatsTest(unittest.TestCase):
     self.assertEqual(exitstats.active_vars[0], 'MinRTT')
     self.assertTrue('MinA' in  exitstats.active_vars)
 
-  def testGetlogf(self):
+  def testGetName(self):
+    '''Check that getlogf successfully create the expected file'''
+    gm = time.gmtime(3600*814234)
+    logdir, logname = exitstats.logName('server', gm, None)
+    self.assertEquals(logdir, '2062/11/20/')
+    self.assertEquals(logname, 'server20621120T10:00:00Z_ALL0.web100')
+
+    gm = time.gmtime(3600*814234)
+    logdir, logname = exitstats.logName('server', gm, '5.4.3.2')
+    self.assertEquals(logdir, '2062/11/20/')
+    self.assertEquals(logname, 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100')
+
+  def testGetLogFileOldBehavior(self):
     '''Check that getlogf successfully create the expected file'''
     # Need to set up the variables key to avoid error.
     exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
@@ -36,7 +48,7 @@ class ExitstatsTest(unittest.TestCase):
       pass
 
     exitstats.server = server = 'server'
-    _ = exitstats.getlogf(3600*814234)
+    _ = exitstats.getLogFile(3600*814234)
 
     try:
       os.stat(logdir + logname)
@@ -50,6 +62,37 @@ class ExitstatsTest(unittest.TestCase):
       os.removedirs(logdir)
     except OSError:
       pass
+
+  def testGetLogFileWithLocalIP(self):
+    '''Check that getlogf successfully create the expected file'''
+    # Need to set up the variables key to avoid error.
+    exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
+
+    logdir = '2062/11/20/'
+    logname = 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100'
+    gm = time.gmtime(3600*814234)
+    try:
+      os.remove(logdir + logname)
+      os.removedirs(logdir)
+    except OSError:
+      pass
+
+    exitstats.server = server = 'server'
+    _ = exitstats.getLogFile(3600*814234, '5.4.3.2')
+
+    try:
+      os.stat(logdir + logname)
+    except OSError as e:
+      print('Expected file not created: ' + logdir + logname)
+      print(e)
+
+    # Clean up
+    try:
+      os.remove(logdir + logname)
+      os.removedirs(logdir)
+    except OSError:
+      pass
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/exitstats_test.py
+++ b/exitstats_test.py
@@ -8,10 +8,27 @@ import logging
 import os
 import unittest
 import time
+from test.test_support import EnvironmentVarGuard
 
 import exitstats
 
 class ExitstatsTest(unittest.TestCase):
+  def remove_file(self, logdir, logname):
+    ''' Utility to remove a file and its directory'''
+    try:
+      os.remove(logdir + logname)
+      os.removedirs(logdir)
+    except OSError:
+      pass
+
+  def assertExists(self, logdir, logname):
+    '''Utility to assert that file exists'''
+    try:
+      os.stat(logdir + logname)
+    except OSError as e:
+      print('Expected file does not exist: ' + logdir + logname)
+      print(e)
+      self.assertIs(e, None)
 
   def testSetkey(self):
     exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
@@ -21,6 +38,14 @@ class ExitstatsTest(unittest.TestCase):
     self.assertEqual(exitstats.active_vars[0], 'MinRTT')
     self.assertTrue('MinA' in  exitstats.active_vars)
 
+  def testUseLocalIP(self):
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'True')
+      self.assertTrue(exitstats.useLocalIP())
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'False')
+      self.assertFalse(exitstats.useLocalIP())
+
   def testGetName(self):
     '''Check that getlogf successfully create the expected file'''
     gm = time.gmtime(3600*814234)
@@ -28,40 +53,55 @@ class ExitstatsTest(unittest.TestCase):
     self.assertEquals(logdir, '2062/11/20/')
     self.assertEquals(logname, 'server20621120T10:00:00Z_ALL0.web100')
 
-    gm = time.gmtime(3600*814234)
-    logdir, logname = exitstats.logName('server', gm, '5.4.3.2')
-    self.assertEquals(logdir, '2062/11/20/')
-    self.assertEquals(logname, 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100')
+    # When we provide the local_ip address, environment shouldn't matter.
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'False')
+      self.assertFalse(exitstats.useLocalIP())
+      logdir, logname = exitstats.logName('server', gm, '5.4.3.2')
+      self.assertEquals(logdir, '2062/11/20/')
+      self.assertEquals(logname, 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100')
+
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'True')
+      self.assertTrue(exitstats.useLocalIP())
+      logdir, logname = exitstats.logName('server', gm, '5.4.3.2')
+      self.assertEquals(logdir, '2062/11/20/')
+      self.assertEquals(logname, 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100')
 
   def testGetLogFileOldBehavior(self):
     '''Check that getlogf successfully create the expected file'''
+
     # Need to set up the variables key to avoid error.
     exitstats.setkey({'foo':3, 'bar':2, 'baz':1})
 
     logdir = '2062/11/20/'
     logname = 'server20621120T10:00:00Z_ALL0.web100'
     gm = time.gmtime(3600*814234)
-    try:
-      os.remove(logdir + logname)
-      os.removedirs(logdir)
-    except OSError:
-      pass
-
     exitstats.server = server = 'server'
-    _ = exitstats.getLogFile(3600*814234)
 
-    try:
-      os.stat(logdir + logname)
-    except OSError as e:
-      print('Expected file not created: ' + logdir + logname)
-      print(e)
+    self.remove_file(logdir, logname)
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'False')
+      self.assertFalse(exitstats.useLocalIP())
+      _ = exitstats.getLogFile(3600*814234)
+
+    self.assertExists(logdir, logname)
+
+    logname_with_ip = 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100'
+    self.remove_file(logdir, logname_with_ip)
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'False')
+      self.assertFalse(exitstats.useLocalIP())
+      # Shouldn't matter if we specify the ip address.
+      _ = exitstats.getLogFile(3600*814234, '5.4.3.2')
+
+    # Check that file does not exist.
+    with self.assertRaises(OSError):
+      print(os.stat(logdir + logname_with_ip))
 
     # Clean up
-    try:
-      os.remove(logdir + logname)
-      os.removedirs(logdir)
-    except OSError:
-      pass
+    self.remove_file(logdir, logname)
+    self.remove_file(logdir, logname_with_ip)
 
   def testGetLogFileWithLocalIP(self):
     '''Check that getlogf successfully create the expected file'''
@@ -71,28 +111,18 @@ class ExitstatsTest(unittest.TestCase):
     logdir = '2062/11/20/'
     logname = 'server20621120T10:00:00Z_ALL0-5.4.3.2.web100'
     gm = time.gmtime(3600*814234)
-    try:
-      os.remove(logdir + logname)
-      os.removedirs(logdir)
-    except OSError:
-      pass
-
     exitstats.server = server = 'server'
-    _ = exitstats.getLogFile(3600*814234, '5.4.3.2')
 
-    try:
-      os.stat(logdir + logname)
-    except OSError as e:
-      print('Expected file not created: ' + logdir + logname)
-      print(e)
+    self.remove_file(logdir, logname)
+    with EnvironmentVarGuard() as env:
+      env.set('SIDESTREAM_USE_LOCAL_IP', 'True')
+      self.assertTrue(exitstats.useLocalIP())
+      _ = exitstats.getLogFile(3600*814234, '5.4.3.2')
+
+    self.assertExists(logdir, logname)
 
     # Clean up
-    try:
-      os.remove(logdir + logname)
-      os.removedirs(logdir)
-    except OSError:
-      pass
-
+    self.remove_file(logdir, logname)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Introduces environment variable SIDESTREAM_USE_LOCAL_IP.  If this is set to true/True/1, then sidestream will use a separate log file for each IP address.

Adds more unit tests to verify behavior with and without the env var set.

This functionality is required to simplify embargo processing in the new pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/23)
<!-- Reviewable:end -->
