### PR TITLE
Add 'do/until' loop around paris_rollins start.

### DIFF
--- a/doside
+++ b/doside
@@ -36,5 +36,9 @@ tdump8000.py $mynode &
 LOGF=$HOME/VAR/logs/paris-traceroute.log
 rm -f $LOGF
 (
-paris_rollins.py -l $BASE/paris-traceroute &
+# Attempt to restart paris_rollins until /dev/shm is mounted by the vserver
+# start sequence.
+until paris_rollins.py -l $BASE/paris-traceroute ; do
+  sleep 1
+done &
 ) >> $LOGF 2>&1


### PR DESCRIPTION
paris_rollins.py depends on /dev/shm for multiprocess worker pools. This resource is mounted in the NPAD slice filesystem during the vserver start up sequence. Unfortunately, there is a race condition between the NPAD init scripts and the vserver 'post-start' script that mounts /dev/shm.

This change adds a retry around the starting of starting paris_rollins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/27)
<!-- Reviewable:end -->
