### PR TITLE
Fixes an issue where doside never exits.

### DIFF
--- a/doside
+++ b/doside
@@ -38,7 +38,11 @@ rm -f $LOGF
 (
 # Attempt to restart paris_rollins until /dev/shm is mounted by the vserver
 # start sequence.
-until paris_rollins.py -l $BASE/paris-traceroute ; do
+while true; do
+  if grep iupui_npad /proc/mounts; then
+    paris_rollins.py -l $BASE/paris-traceroute
+    break
+  fi
   sleep 1
 done &
 ) >> $LOGF 2>&1


### PR DESCRIPTION
This PR fixes a small issue introduced in @fed1a99 that was causing the script `doside` to never exit.  The issue is that [`paris_rollins.py` does not background itself](https://github.com/npad/sidestream/blob/master/doside#L41), thereby causing the `until` loop to hang indefinitely. One side effect of this is that it becomes impossible to kill paris_rollins.py processes (for example in the stop.sh script) because once the parent paris_rollins.py process exits, the `until` loop is freed up and resumes, simply restarting paris_rollins.py. This would go on indefinitely until you kill the `doside` script, and then you can kill all of the paris_rollins.py processes.

This PR introduces a slightly different check on whether it is safe to start paris_rollins.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/28)
<!-- Reviewable:end -->
