### PR TITLE
Moves paris_rollins.py invocation out of a subshell.

### DIFF
--- a/doside
+++ b/doside
@@ -35,14 +35,13 @@ tdump8000.py $mynode &
 
 LOGF=$HOME/VAR/logs/paris-traceroute.log
 rm -f $LOGF
-(
-# Attempt to restart paris_rollins until /dev/shm is mounted by the vserver
-# start sequence.
+
+# Attempt to restart paris_rollins until /dev/shm/iupui_npad is mounted by the
+# vserver start sequence.
 while true; do
   if grep iupui_npad /proc/mounts; then
-    paris_rollins.py -l $BASE/paris-traceroute
+    paris_rollins.py -l $BASE/paris-traceroute >> $LOGF 2>&1 &
     break
   fi
   sleep 1
 done &
-) >> $LOGF 2>&1

--- a/doside
+++ b/doside
@@ -44,4 +44,4 @@ while true; do
     break
   fi
   sleep 1
-done &
+done


### PR DESCRIPTION
As it turns out, PR #28 didn't actually fix the issue of `doside` never exiting. It was likely staying alive because `paris_rollins.py` was being run in a subshell, and because the output of the subshell was redirected to a file, the parent shell never released the subshell (which itself never exited because paris_rollins.py doesn't background itself).  This PR takes the `paris_rollins.py` invocation out of a subshell so that `doside` will properly exit after it has done its thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/29)
<!-- Reviewable:end -->
