### PR TITLE
Readds the backgrounding of the while loop which starts paris_rollins.py

### DIFF
--- a/doside
+++ b/doside
@@ -44,4 +44,4 @@ while true; do
     break
   fi
   sleep 1
-done
+done &


### PR DESCRIPTION
This PR readds the backgrounding of the while loop which starts paris_rollins.py. It turns out that without it, the grep statement never evaluates to true and so the while loops runs indefinitely, and the slice never starts correctly. 

My guess as to why this matters is that somehow whatever process that executes `doside` does not do the mounting of /dev/shm/iupui_npad until *after*  `doside` exits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/30)
<!-- Reviewable:end -->
