### PR TITLE
Fix6bit

### DIFF
--- a/doside
+++ b/doside
@@ -38,8 +38,9 @@ rm -f $LOGF
 
 # Wait until /dev/shm/iupui_npad is mounted by the
 # vserver start sequence.
-until grep iupui_npad /proc/mounts; do
-  sleep 1
+until grep /dev/shm/iupui_npad /proc/mounts; do
+    sleep 1
 done
+
 # Restart paris_rollins
 paris_rollins.py -l $BASE/paris-traceroute >> $LOGF 2>&1 &

--- a/doside
+++ b/doside
@@ -7,6 +7,7 @@ cd $HOME
 
 source $HOME/conf/config.sh
 BASE=$RSYNCDIR
+export SIDESTREAM_USE_LOCAL_IP=true
 mynode=`cat $HOME/VAR/MYNODE`
 
 # This is a whole lot easier...

--- a/doside
+++ b/doside
@@ -36,12 +36,10 @@ tdump8000.py $mynode &
 LOGF=$HOME/VAR/logs/paris-traceroute.log
 rm -f $LOGF
 
-# Attempt to restart paris_rollins until /dev/shm/iupui_npad is mounted by the
+# Wait until /dev/shm/iupui_npad is mounted by the
 # vserver start sequence.
-while true; do
-  if grep iupui_npad /proc/mounts; then
-    paris_rollins.py -l $BASE/paris-traceroute >> $LOGF 2>&1 &
-    break
-  fi
+until grep iupui_npad /proc/mounts; do
   sleep 1
-done &
+done
+# Restart paris_rollins
+paris_rollins.py -l $BASE/paris-traceroute >> $LOGF 2>&1 &

--- a/exitstats.py
+++ b/exitstats.py
@@ -192,7 +192,7 @@ class Web100StatsWriter:
                 exception_count.labels('ipv4 parse error').inc()
                 return 'unparsed'
             else:
-                return '{0}'.format(int(ipv4.group(1),16) % 64)
+                return '{0}'.format(int(ipv4.group(1),10) % 64)
 
     def connectionType(self, remote):
         if remote == '127.0.0.1':

--- a/exitstats_test.py
+++ b/exitstats_test.py
@@ -34,10 +34,11 @@ class TestInternals(unittest.TestCase):
 
   def testIPLastSixBits(self):
     w = exitstats.Web100StatsWriter("server/")
-    self.assertEquals(w.ipLastSixBits('1:2:3::5'), '5')
-    self.assertEquals(w.ipLastSixBits('1:2:3::b5'), '53')
+    self.assertEquals(w.ipLastSixBits('1:2:3::5'), '5')  # 0x05
+    self.assertEquals(w.ipLastSixBits('1:2:3::b5'), '53') # 0x35
     self.assertEquals(w.ipLastSixBits('1.2.3.4'), '4')
-    self.assertEquals(w.ipLastSixBits('1.2.3.157'), '23')
+    self.assertEquals(w.ipLastSixBits('1.2.3.15'), '15')
+    self.assertEquals(w.ipLastSixBits('1.2.3.157'), '29')
     self.assertEquals(w.ipLastSixBits('bad-address'), 'unparsed')
     self.assertEquals(w.ipLastSixBits('bad:address'), 'unparsed')
 
@@ -112,8 +113,9 @@ class TestMonitoring(unittest.TestCase):
     else:
       raise urllib2.URLError('Page not found')
 
+    # Should see lsb = 57, (121 % 64)
     rex = re.compile(
-        r'^sidestream_connection_count[{]lsb="33",type="ipv4"[}] (.*)$', re.M )
+        r'^sidestream_connection_count[{]lsb="57",type="ipv4"[}] (.*)$', re.M )
     count_line = rex.search(response)
     self.assertIsNotNone(count_line, response)
     self.assertEqual(count_line.group(1), '1.0')


### PR DESCRIPTION
Simplifies paris rollins startup, and makes grep more explicit.
Fixes a bug in pulling last six bits from ipv4 addresses.

Enables per IP address logging, for simplified embargo processing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/34)
<!-- Reviewable:end -->
