### PR TITLE
Background the wait for /dev/shm so vserver start can run post-start scripts

### DIFF
--- a/doside
+++ b/doside
@@ -37,11 +37,13 @@ tdump8000.py $mynode &
 LOGF=$HOME/VAR/logs/paris-traceroute.log
 rm -f $LOGF
 
+(
 # Wait until /dev/shm/iupui_npad is mounted by the
 # vserver start sequence.
 until grep /dev/shm/iupui_npad /proc/mounts; do
     sleep 1
 done
 
-# Restart paris_rollins
+# Start paris_rollins
 paris_rollins.py -l $BASE/paris-traceroute >> $LOGF 2>&1 &
+) &


### PR DESCRIPTION
Upon canary testing we discovered that the original version created a live lock: `vserver start` blocked on the iupui_npad init scripts returning before running the `post-start` script that mounts /dev/shm/iupui_npad, and the npad initscripts waited for `/dev/shm/iupui_npad` to be mounted before returning.

This change allows the initscript wait to run in the background, thus preventing the live lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/36)
<!-- Reviewable:end -->
