### PR TITLE
 Track transmit and received bytes per experiment index

### DIFF
--- a/exitstats.py
+++ b/exitstats.py
@@ -28,11 +28,11 @@ connection_count = prom.Counter('sidestream_connection_count',
                                 'Count of connections logged',
                                 ['type', 'index'])
 transmit_bytes = prom.Counter('sidestream_transmit_bytes_total',
-                          'Count of bytes per experiment index',
-                          ['type', 'index'])
+                              'Count of bytes transmitted per experiment index',
+                              ['type', 'index'])
 receive_bytes = prom.Counter('sidestream_receive_bytes_total',
-                          'Count of bytes per experiment index',
-                          ['type', 'index'])
+                             'Count of bytes received per experiment index',
+                             ['type', 'index'])
 exception_count = prom.Counter('sidestream_exception_count',
                                'Count of exceptions.',
                                ['type'])

--- a/exitstats.py
+++ b/exitstats.py
@@ -78,18 +78,19 @@ def start_http_server(port, addr=''):
 def octetToIndex(octet):
     """Converts the given octet to an M-Lab experiment index.
 
-    Because experiment indexes are zero-based, the host context will be -1.
+    Because experiment indexes are zero-based, the host context will be 'host'.
 
-    Invalid octets or values that convert to invalid indexes will return -2.
+    Invalid octets or values that convert to invalid indexes will return
+    'invalid-octet'.
 
     Args:
       octet: int, the last byte of the local IP address.
     Returns:
       index as string
     """
-    # M-Lab host addresses start at 9.
+    # M-Lab host addresses start at 9, and there are only 4 x 13-addr blocks.
     octet -= 9
-    if octet < 0 or octet > 246:
+    if octet < 0 or octet > 244:
         exception_count.labels('invalid octet').inc()
         return 'invalid-octet'
     # M-Lab uses IPv4/26 address blocks of 64 addresses. Within that block, we


### PR DESCRIPTION
This change updates the sidestream prometheus metrics to count the bytes transmitted and received from the host and experiment as identified by the same zero-based 'index' used for experiment configuration.

The index can have special values such as 'host' and error messages for invalid addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npad/sidestream/41)
<!-- Reviewable:end -->
